### PR TITLE
docs: add manual logging section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ app.use(logger({
 
 ---
 
+### Manual Logging
+
+Use `req.log` in your route handlers to emit custom messages at any level:
+
+```js
+app.get('/items', (req, res) => {
+  req.log.debug('Fetching items', { filter: req.query });
+  req.log.info('Items fetched successfully');
+  req.log.warn('Response size is large');
+  req.log.error('Failed to process item', { id: 123 });
+  req.log.fatal('Critical failure!');
+  res.send(items);
+});
+```
+
+This demonstrates how to call `req.log.debug/info/warn/error/fatal` for manual logs.
+
+---
+
 ## ⚙️ Configuration Options
 
 | Option                    | Type       | Default                       | Description                                                                                      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-dynamic-logger",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "express-dynamic-logger",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-dynamic-logger",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Express middleware for dynamic, configurable logging of incoming requests, outgoing responses, missing routes and manual developer logs with custom prefixes, header redaction and flexible options.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
This PR updates the documentation to include a new “Manual Logging” section in README.md.  
It shows how to call all req.log methods (debug, info, warn, error, fatal) inside route handlers.

No changes to the library code—only docs.  
Version bumped to v1.1.3 in package.json.